### PR TITLE
feat: add ROI Total landing page and utilities

### DIFF
--- a/app.config.json
+++ b/app.config.json
@@ -1,0 +1,10 @@
+{
+  "name": "PACK ROI TOTAL",
+  "version": "1.0.0",
+  "modules": [
+    "Hero",
+    "AnimatedStats",
+    "ModulesSelector",
+    "TechStack"
+  ]
+}

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -1,0 +1,26 @@
+import { Variants } from "framer-motion";
+
+export const fadeUp: Variants = {
+  hidden: { opacity: 0, y: 40 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.6, ease: [0.25, 1, 0.5, 1] },
+  },
+};
+
+export const staggerChildren: Variants = {
+  hidden: {},
+  visible: {
+    transition: { staggerChildren: 0.15 },
+  },
+};
+
+export const tilt3D: Variants = {
+  rest: { rotateX: 0, rotateY: 0 },
+  hover: {
+    rotateX: -5,
+    rotateY: 5,
+    transition: { type: "spring", stiffness: 300, damping: 20 },
+  },
+};

--- a/src/app/roi-total/page.tsx
+++ b/src/app/roi-total/page.tsx
@@ -1,0 +1,19 @@
+import Hero from '@/components/roi/Hero'
+import AnimatedStats from '@/components/roi/AnimatedStats'
+import ModulesSelector from '@/components/roi/ModulesSelector'
+import TechStack from '@/components/roi/TechStack'
+import Footer from '@/components/roi/Footer'
+import ScrollProgress from '@/components/roi/ScrollProgress'
+
+export default function RoiTotalPage() {
+  return (
+    <>
+      <ScrollProgress />
+      <Hero />
+      <AnimatedStats />
+      <ModulesSelector />
+      <TechStack />
+      <Footer />
+    </>
+  )
+}

--- a/src/components/roi/AnimatedStats.tsx
+++ b/src/components/roi/AnimatedStats.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { fadeUp, staggerChildren } from '@/animations'
+
+const stats = [
+  { label: 'ROI +2000%', value: '2000%' },
+  { label: '48H Setup', value: '48H' },
+  { label: '100% IA', value: '100%' },
+]
+
+const AnimatedStats = () => (
+  <section className="py-20 bg-black text-white">
+    <motion.div
+      className="mx-auto max-w-4xl grid grid-cols-1 md:grid-cols-3 gap-8 text-center"
+      variants={staggerChildren}
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true }}
+    >
+      {stats.map((stat) => (
+        <motion.div key={stat.label} variants={fadeUp}>
+          <div className="text-4xl font-bold text-[#00F0FF]">{stat.value}</div>
+          <p className="mt-2 text-sm uppercase tracking-widest text-[#E0E0E0]">{stat.label}</p>
+        </motion.div>
+      ))}
+    </motion.div>
+  </section>
+)
+
+export default AnimatedStats

--- a/src/components/roi/Footer.tsx
+++ b/src/components/roi/Footer.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+const Footer = () => (
+  <footer className="py-10 text-center text-sm text-[#E0E0E0] bg-black">
+    © {new Date().getFullYear()} PACK ROI TOTAL™
+  </footer>
+)
+
+export default Footer

--- a/src/components/roi/Hero.tsx
+++ b/src/components/roi/Hero.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { fadeUp, staggerChildren } from '@/animations'
+import { useVoiceCommand } from '@/hooks/useVoiceCommand'
+import ParticleField from '../effects/ParticleField'
+import { hexToRgba } from '@/utils/colorUtils'
+
+const Hero = () => {
+  useVoiceCommand('atlas, crée mon pack roi', () => alert('Lancement du module SIGMA 🌀'))
+
+  return (
+    <section className="relative flex min-h-screen items-center justify-center overflow-hidden bg-gradient-to-br from-[#110011] to-black text-center">
+      <ParticleField />
+      <motion.div
+        variants={staggerChildren}
+        initial="hidden"
+        animate="visible"
+        className="p-8 backdrop-blur-xl bg-white/5 border border-white/10 rounded-xl shadow-2xl"
+      >
+        <motion.h1
+          variants={fadeUp}
+          className="text-5xl md:text-7xl font-extrabold tracking-tight text-transparent bg-clip-text bg-gradient-to-r from-[#FF5EDB] to-[#00F0FF]"
+        >
+          PACK ROI TOTAL™
+        </motion.h1>
+        <motion.p
+          variants={fadeUp}
+          className="mt-4 text-[#E0E0E0] max-w-xl mx-auto"
+        >
+          Interface futuriste holographique, activée par l’IA, conçue pour booster le ROI à l’infini.
+        </motion.p>
+        <motion.button
+          variants={fadeUp}
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.98 }}
+          style={{ boxShadow: `0 0 20px ${hexToRgba('#00F0FF', 0.5)}` }}
+          className="mt-10 px-8 py-3 text-lg font-bold text-black bg-[#00F0FF] rounded-full relative overflow-hidden group"
+        >
+          <span className="absolute inset-0 bg-gradient-to-r from-[#FF5EDB] to-[#00F0FF] opacity-0 group-hover:opacity-100 transition-opacity" />
+          <span className="relative">GÉNÈRE MON PACK ROI</span>
+        </motion.button>
+      </motion.div>
+    </section>
+  )
+}
+
+export default Hero

--- a/src/components/roi/ModulesSelector.tsx
+++ b/src/components/roi/ModulesSelector.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { fadeUp, tilt3D } from '@/animations'
+import React from 'react'
+
+const modules = [
+  'Audience Holographique',
+  'Stratégies Multicanal',
+  'Automation IA',
+]
+
+const ModulesSelector: React.FC = () => {
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.currentTarget
+    const circle = document.createElement('span')
+    const diameter = Math.max(target.clientWidth, target.clientHeight)
+    const radius = diameter / 2
+    circle.style.width = circle.style.height = `${diameter}px`
+    circle.style.left = `${e.clientX - target.getBoundingClientRect().left - radius}px`
+    circle.style.top = `${e.clientY - target.getBoundingClientRect().top - radius}px`
+    circle.classList.add('ripple')
+    const ripple = target.getElementsByClassName('ripple')[0]
+    if (ripple) ripple.remove()
+    target.appendChild(circle)
+  }
+
+  return (
+    <section className="py-20 bg-gradient-to-b from-black to-[#110011] text-white">
+      <h2 className="text-center text-3xl font-bold mb-10">7 Modules Stratégiques</h2>
+      <div className="mx-auto max-w-5xl grid grid-cols-1 md:grid-cols-3 gap-6">
+        {modules.map((m) => (
+          <motion.div
+            key={m}
+            variants={fadeUp}
+            initial="rest"
+            whileHover="hover"
+            animate="rest"
+            className="relative p-6 rounded-xl bg-white/5 backdrop-blur-xl border border-white/10 cursor-pointer overflow-hidden"
+            onClick={handleClick}
+          >
+            <motion.div variants={tilt3D} className="h-full flex items-center justify-center">
+              <span>{m}</span>
+            </motion.div>
+          </motion.div>
+        ))}
+      </div>
+      <style jsx>{`
+        .ripple {
+          position: absolute;
+          border-radius: 50%;
+          transform: scale(0);
+          animation: ripple 600ms linear;
+          background: rgba(255,255,255,0.3);
+        }
+        @keyframes ripple {
+          to {
+            transform: scale(4);
+            opacity: 0;
+          }
+        }
+      `}</style>
+    </section>
+  )
+}
+
+export default ModulesSelector

--- a/src/components/roi/ScrollProgress.tsx
+++ b/src/components/roi/ScrollProgress.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { useScrollProgress } from '@/hooks/useScrollProgress'
+
+const ScrollProgress = () => {
+  const progress = useScrollProgress()
+  return (
+    <div
+      className="fixed top-0 left-0 h-1 bg-[#FF5EDB] z-50"
+      style={{ width: `${progress * 100}%` }}
+    />
+  )
+}
+
+export default ScrollProgress

--- a/src/components/roi/TechStack.tsx
+++ b/src/components/roi/TechStack.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { fadeUp, staggerChildren } from '@/animations'
+
+const icons = [
+  { src: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nextjs/nextjs-original.svg', alt: 'Next.js' },
+  { src: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/tailwindcss/tailwindcss-plain.svg', alt: 'TailwindCSS' },
+  { src: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/react/react-original.svg', alt: 'Framer Motion' },
+]
+
+const TechStack = () => (
+  <section className="py-20 bg-black text-white">
+    <h2 className="text-center text-3xl font-bold mb-10">Stack Technologique</h2>
+    <motion.div
+      className="flex justify-center gap-10"
+      variants={staggerChildren}
+      initial="hidden"
+      whileInView="visible"
+      viewport={{ once: true }}
+    >
+      {icons.map((icon) => (
+        <motion.img
+          key={icon.alt}
+          variants={fadeUp}
+          src={icon.src}
+          alt={icon.alt}
+          className="h-12 w-12"
+        />
+      ))}
+    </motion.div>
+  </section>
+)
+
+export default TechStack

--- a/src/hooks/useScrollProgress.ts
+++ b/src/hooks/useScrollProgress.ts
@@ -1,0 +1,21 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export function useScrollProgress() {
+  const [progress, setProgress] = useState(0)
+
+  useEffect(() => {
+    const update = () => {
+      const scrollTop = window.scrollY
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight
+      setProgress(docHeight > 0 ? scrollTop / docHeight : 0)
+    }
+
+    update()
+    window.addEventListener('scroll', update)
+    return () => window.removeEventListener('scroll', update)
+  }, [])
+
+  return progress
+}

--- a/src/hooks/useVoiceCommand.ts
+++ b/src/hooks/useVoiceCommand.ts
@@ -1,0 +1,32 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export function useVoiceCommand(phrase: string, callback: () => void) {
+  useEffect(() => {
+    const SpeechRecognition =
+      (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition
+    if (!SpeechRecognition) return
+
+    const recognition = new SpeechRecognition()
+    recognition.continuous = true
+    recognition.lang = 'fr-FR'
+
+    const handleResult = (event: SpeechRecognitionEvent) => {
+      for (const result of event.results) {
+        const transcript = result[0].transcript.trim().toLowerCase()
+        if (transcript.includes(phrase.toLowerCase())) {
+          callback()
+        }
+      }
+    }
+
+    recognition.addEventListener('result', handleResult)
+    recognition.start()
+
+    return () => {
+      recognition.removeEventListener('result', handleResult)
+      recognition.stop()
+    }
+  }, [phrase, callback])
+}

--- a/src/meta.config.ts
+++ b/src/meta.config.ts
@@ -1,0 +1,7 @@
+const meta = {
+  title: 'PACK ROI TOTAL',
+  description: 'Interface futuriste holographique pour booster votre ROI.',
+  themeColor: '#110011',
+}
+
+export default meta

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,22 @@
+export const theme = {
+  colors: {
+    background: '#110011',
+    neonPink: '#FF5EDB',
+    aqua: '#00F0FF',
+    textPrimary: '#FFFFFF',
+    textSecondary: '#E0E0E0',
+  },
+  fonts: {
+    heading: 'Sora, sans-serif',
+    display: 'Orbitron, sans-serif',
+    body: 'Montserrat, sans-serif',
+  },
+  breakpoints: {
+    sm: '640px',
+    md: '768px',
+    lg: '1024px',
+    xl: '1280px',
+  },
+}
+
+export default theme

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -1,0 +1,8 @@
+export function hexToRgba(hex: string, alpha: number) {
+  const sanitized = hex.replace('#', '')
+  const bigint = parseInt(sanitized, 16)
+  const r = (bigint >> 16) & 255
+  const g = (bigint >> 8) & 255
+  const b = bigint & 255
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}


### PR DESCRIPTION
## Summary
- scaffold ROI Total landing page with hero, stats, module selector, tech stack and footer
- add shared animation, theme, meta config and app config files
- implement voice command, scroll progress and color utility hooks

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run lint` *(interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6890c5a7492c832e9f6c0451cca57caf